### PR TITLE
58 feature/exchange

### DIFF
--- a/src/main/java/com/hana/hana1pick/domain/common/service/AccountService.java
+++ b/src/main/java/com/hana/hana1pick/domain/common/service/AccountService.java
@@ -138,8 +138,8 @@ public class AccountService {
             log.info("isMoaClubTransaction={}, isForeignCurrency={}", isMoaClubTransaction, isForeignCurrency);
 
             // 입,출금 계좌 구분
-            AccountHistoryInfoDto outAcc = null;
-            AccountHistoryInfoDto inAcc = null;
+            AccountHistoryInfoDto outAcc;
+            AccountHistoryInfoDto inAcc;
 
             //  모아클럽이면서 원화가 아닌 경우
             if (isMoaClubTransaction && isForeignCurrency) {
@@ -149,14 +149,14 @@ public class AccountService {
                 log.info("Calculated foreignAmountWithFee={}", foreignAmountWithFee);
 
                 // 원화로 출금하고 외화로 입금
-                // outAccId에서 환전된 원화로 출금 (수수료 계산 필요)
-                outAcc = handleAccBalance(outAccId, -foreignAmountWithFee);
 
-                // inAccId가 모아 클럽 계좌이면 요청 금액(amount)으로 입금
-                if (getAccountTypeByAccId(inAccId).equals("moaclub")) {
-                    inAcc = handleAccBalance(inAccId, amount);
-                } else {
+                //  outAccId가 모아 클럽 계좌이면 환전 금액(foreignAmountWithFee)으로 입금
+                if (getAccountTypeByAccId(outAccId).equals("moaclub")) {
+                    outAcc = handleAccBalance(outAccId, -amount);
                     inAcc = handleAccBalance(inAccId, foreignAmountWithFee);
+                } else { // 일반 -> 모아
+                    outAcc = handleAccBalance(outAccId, -foreignAmountWithFee);
+                    inAcc = handleAccBalance(inAccId, amount);
                 }
 
                 // 거래 로그 생성

--- a/src/main/java/com/hana/hana1pick/domain/common/service/AccountService.java
+++ b/src/main/java/com/hana/hana1pick/domain/common/service/AccountService.java
@@ -11,12 +11,17 @@ import com.hana.hana1pick.domain.common.entity.Account;
 import com.hana.hana1pick.domain.common.entity.Accounts;
 import com.hana.hana1pick.domain.common.repository.AccountsRepository;
 import com.hana.hana1pick.domain.deposit.repository.DepositRepository;
+import com.hana.hana1pick.domain.exchange.service.ExchangeFeeService;
+import com.hana.hana1pick.domain.exchange.service.ExchangeRateService;
+import com.hana.hana1pick.domain.exchange.service.ExchangeService;
+import com.hana.hana1pick.domain.moaclub.entity.Currency;
 import com.hana.hana1pick.domain.moaclub.repository.MoaClubRepository;
 import com.hana.hana1pick.domain.user.service.UserTrsfLimitService;
 import com.hana.hana1pick.global.exception.BaseException;
 import com.hana.hana1pick.global.exception.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
@@ -43,6 +48,9 @@ public class AccountService {
     private final MoaClubRepository moaClubRepository;
     private final AccHistoryService accountHistoryService;
     private final UserTrsfLimitService userTrsfLimitService;
+    private final ExchangeService exchangeService; // 환전 서비스
+    private ExchangeRateService exchangeRateService;  // 환율 서비스
+    private ExchangeFeeService exchangeFeeService;  // 수수료 서비스
 
     final PlatformTransactionManager transactionManager;
 
@@ -93,33 +101,77 @@ public class AccountService {
         return result;
     }
 
-    public BaseResponse.SuccessResult cashOut(CashOutReqDto request){
+    public BaseResponse.SuccessResult cashOut(CashOutReqDto request) {
         UUID userIdx = request.getUserIdx();
         String outAccId = request.getOutAccId();
         String inAccId = request.getInAccId();
         Long amount = request.getAmount();
 
+        log.info("Starting cashOut process: userIdx={}, outAccId={}, inAccId={}, amount={}", userIdx, outAccId, inAccId, amount);
+
         // 1. 입출금 계좌의 유효성 검사
-        handleAccStatus(outAccId);
-        handleAccStatus(inAccId);
+        try {
+            handleAccStatus(outAccId);
+            handleAccStatus(inAccId);
+        } catch (Exception e) {
+            log.error("Account status handling failed", e);
+            throw new BaseException(ACCOUNT_CASH_OUT_FAIL);
+        }
 
         // 2. 출금 계좌 소유자의 회원 이체한도 초과 확인
-        if(userTrsfLimitService.checkTrsfLimit(userIdx, amount)){
-            throw new BaseException(USER_TRSF_LIMIT_OVER);
-        };
+        try {
+            if (userTrsfLimitService.checkTrsfLimit(userIdx, amount)) {
+                throw new BaseException(USER_TRSF_LIMIT_OVER);
+            }
+        } catch (Exception e) {
+            log.error("User transfer limit check failed", e);
+            throw new BaseException(ACCOUNT_CASH_OUT_FAIL);
+        }
 
         // 3. 입출금 및 입출금 로그 생성
         TransactionStatus status = transactionManager.getTransaction(new DefaultTransactionDefinition());
         try {
             // 3-1. 입출금
-            // TODO: 원화 통장: 무조건 원화
+            boolean isMoaClubTransaction = getAccountTypeByAccId(outAccId).equals("moaclub") || getAccountTypeByAccId(inAccId).equals("moaclub");
+            boolean isForeignCurrency = !request.getCurrency().equals(Currency.KRW);
 
-            AccountHistoryInfoDto outAcc = handleAccBalance(outAccId, -amount);
-            AccountHistoryInfoDto inAcc = handleAccBalance(inAccId, +amount);
+            log.info("isMoaClubTransaction={}, isForeignCurrency={}", isMoaClubTransaction, isForeignCurrency);
+
+            // 입,출금 계좌 구분
+            AccountHistoryInfoDto outAcc = null;
+            AccountHistoryInfoDto inAcc = null;
+
+            //  모아클럽이면서 원화가 아닌 경우
+            if (isMoaClubTransaction && isForeignCurrency) {
+                // 환율 및 수수료 적용
+                long foreignAmountWithFee = exchangeService.calculateExchangeAmount(request.getCurrency().name(), amount);
+
+                log.info("Calculated foreignAmountWithFee={}", foreignAmountWithFee);
+
+                // 원화로 출금하고 외화로 입금
+                // outAccId에서 환전된 원화로 출금 (수수료 계산 필요)
+                outAcc = handleAccBalance(outAccId, -foreignAmountWithFee);
+
+                // inAccId가 모아 클럽 계좌이면 요청 금액(amount)으로 입금
+                if (getAccountTypeByAccId(inAccId).equals("moaclub")) {
+                    inAcc = handleAccBalance(inAccId, amount);
+                } else {
+                    inAcc = handleAccBalance(inAccId, foreignAmountWithFee);
+                }
+
+                // 거래 로그 생성
+                createAccHis(request, outAccId, inAccId, outAcc, inAcc, foreignAmountWithFee);
+
+            } else {
+                // 일반 거래
+                outAcc = handleAccBalance(outAccId, -amount);
+                inAcc = handleAccBalance(inAccId, amount);
+
+                createAccHis(request, outAccId, inAccId, outAcc, inAcc, amount);
+            }
+
             transactionManager.commit(status);
-
-            // 3-2. 입출금 로그 생성
-            createAccHis(request, outAccId, inAccId, outAcc, inAcc);
+            log.info("Transaction committed successfully");
 
             // 3-3. 사용자 누적 금액 수정
             if (!getAccountTypeByAccId(outAccId).equals("moaclub")) {
@@ -127,19 +179,21 @@ public class AccountService {
             }
         } catch (Exception e) {
             transactionManager.rollback(status);
+            log.error("Transaction failed and rolled back", e);
             throw new BaseException(ACCOUNT_CASH_OUT_FAIL);
         }
 
+        log.info("cashOut process completed successfully");
         return success(ACCOUNT_CASH_OUT_SUCCESS);
     }
 
-    private void createAccHis(CashOutReqDto request, String outAccId, String inAccId, AccountHistoryInfoDto outAcc, AccountHistoryInfoDto inAcc) {
-        // TODO: 모아클럽 거래이면서 거래 통화가 KRW가 아닌 경우 거래내역 2개 생성
+
+    private void createAccHis(CashOutReqDto request, String outAccId, String inAccId, AccountHistoryInfoDto outAcc, AccountHistoryInfoDto inAcc, Long changeAmount) {
+        // 모아클럽 거래이면서 거래 통화가 KRW인 경우 거래내역 2개 생성
         if ((outAccId.substring(3, 5).equals("02") || inAccId.substring(3, 5).equals("02")) && !request.getCurrency().equals(KRW)) {
             // 외화 거래
             accountHistoryService.createAccountHistory(outAcc, inAcc, request.getMemo(), request.getAmount(), request.getTransType(), request.getHashtag(), true);
-            // 환율 계산 - 해야함
-            Long changeAmount = request.getAmount() * 1000; // 환율 곱하기(+ 수수료)
+
             // 원화 거래
             accountHistoryService.createAccountHistory(outAcc, inAcc, request.getMemo(), changeAmount, request.getTransType(), request.getHashtag(), false);
         } else {

--- a/src/main/java/com/hana/hana1pick/domain/exchange/controller/ExchangeController.java
+++ b/src/main/java/com/hana/hana1pick/domain/exchange/controller/ExchangeController.java
@@ -1,0 +1,31 @@
+package com.hana.hana1pick.domain.exchange.controller;
+
+import com.hana.hana1pick.domain.exchange.entity.ExchangeFee;
+import com.hana.hana1pick.domain.exchange.repository.ExchangeFeeRepository;
+import com.hana.hana1pick.domain.exchange.service.ExchangeFeeService;
+import com.hana.hana1pick.domain.exchange.service.ExchangeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/exchange")
+public class ExchangeController {
+    @Autowired
+    private ExchangeService exchangeService;
+    @Autowired
+    private ExchangeFeeService exchangeFeeService;
+
+    // 환전하기
+    @GetMapping("/calculate")
+    public double calculateExchange(
+            @RequestParam String fromCurrency,
+            @RequestParam String toCurrency,
+            @RequestParam Long amount) {
+        return exchangeService.calculateExchangeAmount(toCurrency, amount);
+    }
+
+    @PostMapping("/fees")
+    public void saveFee(@RequestBody ExchangeFee fee) {
+        exchangeFeeService.saveFee(fee);
+    }
+}

--- a/src/main/java/com/hana/hana1pick/domain/exchange/controller/ExchangeRateController.java
+++ b/src/main/java/com/hana/hana1pick/domain/exchange/controller/ExchangeRateController.java
@@ -1,0 +1,46 @@
+package com.hana.hana1pick.domain.exchange.controller;
+
+import com.hana.hana1pick.domain.exchange.service.ExchangeRateService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/exchange-rates")
+public class ExchangeRateController {
+    @Autowired
+    private ExchangeRateService exchangeRateService;
+
+    //   getExchangeRate(Currency currency)
+//    @GetMapping("/current")
+//    public Map<String, Double> getExchangeRate() {
+//        return exchangeRateService.getExchangeRate();
+//    }
+
+    @GetMapping("/previous-day")
+    public Map<String, Double> getPreviousDayRates() {
+        LocalDate previousDay = LocalDate.now().minusDays(1);
+        Map<String, Double> rates = exchangeRateService.getRatesForDate(previousDay);
+        if (rates == null || rates.isEmpty()) {
+            // Handle case where no rates are found for the previous day
+            Map<String, Double> defaultRates = new HashMap<>();
+            defaultRates.put("USD", 0.0);
+            defaultRates.put("JPY", 0.0);
+            defaultRates.put("CNY", 0.0);
+            return defaultRates;
+        }
+        return rates;
+    }
+
+    @GetMapping("/date")
+    public Map<String, Double> getRatesForDate(@RequestParam String date) {
+        LocalDate localDate = LocalDate.parse(date);
+        return exchangeRateService.getRatesForDate(localDate);
+    }
+}

--- a/src/main/java/com/hana/hana1pick/domain/exchange/entity/ExchangeFee.java
+++ b/src/main/java/com/hana/hana1pick/domain/exchange/entity/ExchangeFee.java
@@ -1,0 +1,33 @@
+package com.hana.hana1pick.domain.exchange.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class ExchangeFee {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 통화: KRW, JPY, CNY
+    @Column
+    private String currency;
+
+    // 환율 수수료
+    @Column(name = "fee_rate")
+    private Double feeRate;
+
+    // 생성일
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    // Getters and Setters
+}

--- a/src/main/java/com/hana/hana1pick/domain/exchange/entity/ExchangeRate.java
+++ b/src/main/java/com/hana/hana1pick/domain/exchange/entity/ExchangeRate.java
@@ -1,0 +1,30 @@
+package com.hana.hana1pick.domain.exchange.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class ExchangeRate {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String currency;
+
+    @Column
+    private Double rate;
+
+    @Column
+    private LocalDate date;
+
+    // Getters and Setters
+}

--- a/src/main/java/com/hana/hana1pick/domain/exchange/repository/ExchangeFeeRepository.java
+++ b/src/main/java/com/hana/hana1pick/domain/exchange/repository/ExchangeFeeRepository.java
@@ -1,0 +1,9 @@
+package com.hana.hana1pick.domain.exchange.repository;
+import com.hana.hana1pick.domain.exchange.entity.ExchangeFee;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ExchangeFeeRepository extends JpaRepository<ExchangeFee, Long> {
+    ExchangeFee findByCurrency(String currency);
+}

--- a/src/main/java/com/hana/hana1pick/domain/exchange/repository/ExchangeRateRepository.java
+++ b/src/main/java/com/hana/hana1pick/domain/exchange/repository/ExchangeRateRepository.java
@@ -1,0 +1,18 @@
+package com.hana.hana1pick.domain.exchange.repository;
+
+import com.hana.hana1pick.domain.exchange.entity.ExchangeRate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ExchangeRateRepository extends JpaRepository<ExchangeRate, Long> {
+    List<ExchangeRate> findByDate(LocalDate date);
+    @Query("SELECT er FROM ExchangeRate er WHERE er.currency = :currency AND er.date = :date")
+    Optional<ExchangeRate> findByCurrencyAndDate(@Param("currency") String currency, @Param("date") LocalDate date);
+}

--- a/src/main/java/com/hana/hana1pick/domain/exchange/service/ExchangeFeeService.java
+++ b/src/main/java/com/hana/hana1pick/domain/exchange/service/ExchangeFeeService.java
@@ -1,0 +1,22 @@
+package com.hana.hana1pick.domain.exchange.service;
+
+import com.hana.hana1pick.domain.exchange.entity.ExchangeFee;
+import com.hana.hana1pick.domain.exchange.repository.ExchangeFeeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ExchangeFeeService {
+    @Autowired
+    private ExchangeFeeRepository repository;
+
+    public ExchangeFee getFeeByCurrency(String currency) {
+        return repository.findByCurrency(currency);
+    }
+
+    public void saveFee(ExchangeFee fee) {
+        repository.save(fee);
+    }
+}

--- a/src/main/java/com/hana/hana1pick/domain/exchange/service/ExchangeRateService.java
+++ b/src/main/java/com/hana/hana1pick/domain/exchange/service/ExchangeRateService.java
@@ -1,0 +1,81 @@
+package com.hana.hana1pick.domain.exchange.service;
+
+import com.hana.hana1pick.domain.exchange.entity.ExchangeRate;
+import com.hana.hana1pick.domain.exchange.repository.ExchangeRateRepository;
+import com.hana.hana1pick.domain.moaclub.entity.Currency;
+import com.hana.hana1pick.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ExchangeRateService {
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final String apiUrl = "https://api.exchangerate-api.com/v4/latest/KRW";
+
+    @Autowired
+    private ExchangeRateRepository exchangeRateRepository;
+
+    public Map<String, Double> getCurrentRatesAsDoubles() {
+        String url = UriComponentsBuilder.fromHttpUrl(apiUrl).toUriString();
+        Map<String, Object> response = restTemplate.getForObject(url, Map.class);
+
+        // 로그 추가
+        System.out.println("API Response: " + response);
+
+        Map<String, Double> rates = new HashMap<>();
+        if (response != null && response.get("rates") instanceof Map) {
+            Map<String, Object> ratesObject = (Map<String, Object>) response.get("rates");
+            for (Map.Entry<String, Object> entry : ratesObject.entrySet()) {
+                try {
+                    rates.put(entry.getKey(), ((Number) entry.getValue()).doubleValue());
+                } catch (Exception e) {
+                    System.err.println("Error parsing rate for currency: " + entry.getKey());
+                    e.printStackTrace();
+                }
+            }
+        }
+        return rates;
+    }
+
+    public double getExchangeRate(Currency currency) {
+        Map<String, Double> rates = getCurrentRatesAsDoubles();
+        return rates.get(currency.name());
+    }
+
+    public Map<String, Double> getRatesForDate(LocalDate date) {
+        List<ExchangeRate> exchangeRates = exchangeRateRepository.findByDate(date);
+        if (exchangeRates.isEmpty()) {
+            return null;
+        }
+        Map<String, Double> rates = new HashMap<>();
+        for (ExchangeRate exchangeRate : exchangeRates) {
+            rates.put(exchangeRate.getCurrency(), exchangeRate.getRate());
+        }
+        return rates;
+    }
+
+    public void saveRates(Map<String, Double> rates) {
+        LocalDate today = LocalDate.now();
+        for (Map.Entry<String, Double> entry : rates.entrySet()) {
+            Optional<ExchangeRate> existingRate = exchangeRateRepository.findByCurrencyAndDate(entry.getKey(), today);
+            if (existingRate.isEmpty()) {
+                ExchangeRate exchangeRate = ExchangeRate.builder()
+                        .currency(entry.getKey())
+                        .rate(entry.getValue().doubleValue())
+                        .date(today)
+                        .build();
+                exchangeRateRepository.save(exchangeRate);
+            }
+        }
+    }
+}

--- a/src/main/java/com/hana/hana1pick/domain/exchange/service/ExchangeService.java
+++ b/src/main/java/com/hana/hana1pick/domain/exchange/service/ExchangeService.java
@@ -1,0 +1,56 @@
+package com.hana.hana1pick.domain.exchange.service;
+
+import com.hana.hana1pick.domain.exchange.entity.ExchangeFee;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ExchangeService {
+    @Autowired
+    private ExchangeRateService exchangeRateService;
+
+    @Autowired
+    private ExchangeFeeService exchangeFeeService;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final String apiUrl = "https://api.exchangerate-api.com/v4/latest/KRW";
+
+    //  환율 테이블의 수수료를 가져오고 외부 환율 API를 호출해서 환전하기
+    public Long calculateExchangeAmount(String toCurrency, Long amount) {
+        Map<String, Double> currentRates = exchangeRateService.getCurrentRatesAsDoubles();
+
+        Double rate = currentRates.get(toCurrency);
+        if (rate == null || rate == 0) {
+            throw new IllegalArgumentException("Invalid exchange rate for currency: " + toCurrency);
+        }
+
+        // 환율: (1/당일 환율) 로 계산
+        // by zero 오류를 방지하기 위해 0으로 나누는 것을 방지=> rate: double로 형변환
+        Double exchangeRate = 1 / rate;
+
+        ExchangeFee fee = exchangeFeeService.getFeeByCurrency(toCurrency);
+        Double feeRate = (fee != null) ? fee.getFeeRate() : 0.0;
+
+        Double exchangeAmount = amount * exchangeRate;
+        Double feeAmount = exchangeAmount * feeRate;
+
+        return Math.round(exchangeAmount - feeAmount);
+    }
+
+    private Map<String, Double> getCurrentRatesAsDoubles() {
+        Map<String, Object> response = restTemplate.getForObject(apiUrl, Map.class);
+        Map<String, Double> rates = new HashMap<>();
+        for (Map.Entry<String, Object> entry : ((Map<String, Object>) response.get("rates")).entrySet()) {
+            rates.put(entry.getKey(), ((Number) entry.getValue()).doubleValue());
+        }
+        return rates;
+    }
+}


### PR DESCRIPTION
## 개요
- close #58 

## 작업사항
- 엔티티 클래스 생성
- 리포지토리 인터페이스 생성
- 서비스 클래스 생성
- 입/출금시 수수료 계산 로직 구현
- 컨트롤러 클래스 생성
 1. 환율Service에 통화, 값 받아와서 환전하는 서비스 코드 추가
 2. 1의 서비스 코드에서는 환율 테이블의 수수료를 가져오고 외부 환율 API를 호출해서 환전하기
 3. AccountService의 cashOut 96번째 줄에서 request.inAccId가 모아클럽이거나 request.outAccId가 모아클럽이면서 원화가 아닌 경우(<이거 136번째 조건 참고) 3-1 입출금이 이루어질 때 원화는 원화로 계산하고, 외화는 외화로 계산하기(외화는 1의 서비스 코드 호출)
 4. createAccHis에서도 환전된 값으로 거래 2개 만들기
- swagger 테스트
- 일본 계좌 생성 후 계좌 이체 테스트
- 미국 계좌 생성 후 계좌 이체 테스트
- 중국 계좌 생성 후 계좌 이체 테스트

## 참고자료
<!-- 참고자료 등 기타 내용 작성 -->
